### PR TITLE
Undo/Redo

### DIFF
--- a/ec4-v2-vue/README.md
+++ b/ec4-v2-vue/README.md
@@ -46,8 +46,8 @@ yarn lint
 
 ## TODO
 
-- Write protect bundle checkmark? Is there an easy way to make all inputs/links/... disabled?
 - Undo functionality somehow? Pinia has something built in
+- Write protect bundle checkmark? Is there an easy way to make all inputs/links/... disabled?
 - IDEA: Shift + Ctrl + nav or eg Alt + Tab could select a range of encoders (eg for inserting incremental values)
 - Send to EC4 activity indicator? Or a modal you can't dismiss? Or a simulated progress bar that also blocks further midi IO?
 

--- a/ec4-v2-vue/src/components/ChannelInput.vue
+++ b/ec4-v2-vue/src/components/ChannelInput.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useTemplateRef } from 'vue';
+
 const emit = defineEmits<{
   (event: 'focus', target: FocusEvent): void;
 }>();
@@ -9,6 +11,8 @@ const props = defineProps<{
   tabIndex?: number;
 }>();
 
+const input = useTemplateRef('input');
+
 function handleInput(e: Event) {
   const asNumber = parseInt((e.target as HTMLInputElement).value || '0', 10);
   model.value = isNaN(asNumber) ? 1 : ((asNumber - 1 + 16) % 16) + 1;
@@ -18,12 +22,16 @@ defineExpose({
   get value() {
     return model.value;
   },
+  focus() {
+    input.value?.focus();
+  },
 });
 </script>
 
 <template>
   <input
     class="width_3"
+    ref="input"
     :value="model"
     @input="handleInput($event)"
     type="number"

--- a/ec4-v2-vue/src/components/FrontPanel.vue
+++ b/ec4-v2-vue/src/components/FrontPanel.vue
@@ -6,7 +6,7 @@ import { ref, watch } from 'vue';
 import { useEc4Store } from '@/stores/faderfox-ec4.ts';
 import LegendButton from '@/components/LegendButton.vue';
 import { onKeyStroke } from '@vueuse/core';
-import { Undo2 } from 'lucide-vue-next';
+import { Undo2, Redo2 } from 'lucide-vue-next';
 
 const props = defineProps<{
   groupId: number;
@@ -71,14 +71,21 @@ onKeyStroke(['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'], (e) => {
   <main>
     <div class="beta-notice dymo-label">BETA</div>
     <div id="save-indicator" v-if="showSaveIndicator">💾</div>
-    <div
-      id="undo-button"
-      class="undo-button"
-      :class="{ 'can-undo': ec4.history.canUndo }"
+    <button
+      class="undo history-button"
+      :disabled="!ec4.history.canUndo"
+      :class="{ 'can-do': ec4.history.canUndo }"
       @click="ec4.history.undo()"
     >
       <undo-2 class="icon" />
-    </div>
+    </button>
+    <button
+      class="redo history-button"
+      :class="{ 'can-do': ec4.history.canRedo }"
+      @click="ec4.history.redo()"
+    >
+      <redo-2 class="icon" />
+    </button>
     <legend-button id="legend-button" />
     <mode-selector class="mode-selector" />
     <oled
@@ -207,9 +214,26 @@ main {
   right: 35px;
 }
 
-#undo-button {
+.history-button {
   position: absolute;
-  top: 81px;
-  left: 5px;
+  left: 36px;
+  width: 42px;
+  height: 42px;
+  color: $yellow-500;
+  border: 2px solid $yellow-500;
+  background: transparent;
+
+  border-radius: 50%;
+  &.undo {
+    top: 180px;
+  }
+  &.redo {
+    top: 79px;
+  }
+  &.can-do {
+    cursor: pointer;
+    color: $yellow-200;
+    border-color: $yellow-200;
+  }
 }
 </style>

--- a/ec4-v2-vue/src/components/FrontPanel.vue
+++ b/ec4-v2-vue/src/components/FrontPanel.vue
@@ -6,6 +6,7 @@ import { ref, watch } from 'vue';
 import { useEc4Store } from '@/stores/faderfox-ec4.ts';
 import LegendButton from '@/components/LegendButton.vue';
 import { onKeyStroke } from '@vueuse/core';
+import { Undo2 } from 'lucide-vue-next';
 
 const props = defineProps<{
   groupId: number;
@@ -70,6 +71,14 @@ onKeyStroke(['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'], (e) => {
   <main>
     <div class="beta-notice dymo-label">BETA</div>
     <div id="save-indicator" v-if="showSaveIndicator">💾</div>
+    <div
+      id="undo-button"
+      class="undo-button"
+      :class="{ 'can-undo': ec4.history.canUndo }"
+      @click="ec4.history.undo()"
+    >
+      <undo-2 class="icon" />
+    </div>
     <legend-button id="legend-button" />
     <mode-selector class="mode-selector" />
     <oled
@@ -196,5 +205,11 @@ main {
   position: absolute;
   top: 81px;
   right: 35px;
+}
+
+#undo-button {
+  position: absolute;
+  top: 81px;
+  left: 5px;
 }
 </style>

--- a/ec4-v2-vue/src/components/SingleEncoder.vue
+++ b/ec4-v2-vue/src/components/SingleEncoder.vue
@@ -208,6 +208,7 @@ defineExpose({
         <channel-input
           v-model="control.numbers.channel"
           @focus="setNameActive(false, $event.target)"
+          ref="encoderInput"
           :tabindex="props.nameActive ? -1 : 0"
         />
       </template>
@@ -216,6 +217,7 @@ defineExpose({
         <channel-input
           v-model="control.numbers.pb_channel"
           @focus="setNameActive(false, $event.target)"
+          ref="encoderInput"
           :tabindex="props.nameActive ? -1 : 0"
         />
       </template>

--- a/ec4-v2-vue/src/components/StoredConfs.vue
+++ b/ec4-v2-vue/src/components/StoredConfs.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type BundleMeta, useStorage } from '@/composables/storage.ts';
+import { type DbBundleMeta, useStorage } from '@/composables/storage.ts';
 import { formatDate, useDropZone } from '@vueuse/core';
 import Modal from '@/components/Modal.vue';
 import { useEc4Store } from '@/stores/faderfox-ec4.ts';
@@ -26,7 +26,7 @@ function dateString(date: number) {
   return formatDate(new Date(date), 'DD/MM/YYYY HH:mm');
 }
 
-async function deleteBundle(meta: BundleMeta) {
+async function deleteBundle(meta: DbBundleMeta) {
   const shouldNavigate = meta.id === ec4.activeBundleId;
   await confirmDeleteDialog.value
     ?.showIt(
@@ -46,19 +46,19 @@ const ec4 = useEc4Store();
 
 const midi = useMidi();
 
-async function editBundle(meta: BundleMeta) {
+async function editBundle(meta: DbBundleMeta) {
   if (meta.id === ec4.activeBundleId) return;
   await router.push({ name: 'bundle', params: { bundleId: meta.id } });
 }
 
-async function downloadBundle(meta: BundleMeta) {
+async function downloadBundle(meta: DbBundleMeta) {
   const bundle = await storage.getBundle(meta);
   if (!bundle?.bytes) return;
   console.log('Saving bytes to disk', bundle.bytes.length);
   await fileStorage.saveSysexDataToDisk(bundle.bytes, meta.name);
 }
 
-async function sendBundle(meta: BundleMeta) {
+async function sendBundle(meta: DbBundleMeta) {
   const bundle = await storage.getBundle(meta);
   if (!bundle?.bytes) return;
   midi.sendBundle(bundle);
@@ -109,7 +109,7 @@ async function onDrop(files: File[] | null, e: DragEvent) {
           :class="{ active: meta.id === ec4.activeBundleId }"
           @click.capture.prevent="editBundle(meta)"
           v-for="meta in (storage.bundleMetas.value || []).filter(
-            (m: BundleMeta | undefined) => !!m,
+            (m: DbBundleMeta | undefined) => !!m,
           )"
           :key="meta.id"
         >

--- a/ec4-v2-vue/src/composables/history.ts
+++ b/ec4-v2-vue/src/composables/history.ts
@@ -1,0 +1,66 @@
+import { type DbBundle, DbBundleDelta, type DbBundleMeta } from '@/composables/storage.ts';
+import { computed, ref } from 'vue';
+import { useEc4Store } from '@/stores/faderfox-ec4.ts';
+
+export default function useHistory() {
+  const undoStack = ref<DbBundleDelta[]>([]);
+  const redoStack = ref<DbBundleDelta[]>([]);
+
+  function pushEdit(delta: DbBundleDelta) {
+    undoStack.value.push(delta);
+    redoStack.value = [];
+  }
+
+  function undoFrom(bundle: DbBundle, meta: DbBundleMeta) {
+    if (undoStack.value.length === 0) return;
+    const delta = undoStack.value.pop();
+    if (!delta) return;
+    redoStack.value.push(delta);
+    delta.applyBackward(bundle, meta);
+  }
+
+  function redoFrom(bundle: DbBundle, meta: DbBundleMeta) {
+    if (redoStack.value.length === 0) return;
+    const delta = redoStack.value.pop();
+    if (!delta) return;
+    undoStack.value.push(delta);
+    delta.applyForward(bundle, meta);
+  }
+
+  const canUndo = computed(() => undoStack.value.length > 0);
+  const canRedo = computed(() => redoStack.value.length > 0);
+
+  const ec4 = useEc4Store();
+
+  function undo() {
+    if (!canUndo.value) return;
+    const [bundle, meta] = ec4.currentDbState();
+    if (!bundle || !meta || !bundle.id) throw Error('No bundle found');
+    undoFrom(bundle as DbBundle, meta as DbBundleMeta);
+    // Avoid pushing the undo onto the undo stack when saving after this operation
+    ec4.skipHistory();
+    ec4.setState(bundle as DbBundle, meta as DbBundleMeta);
+  }
+
+  function redo() {
+    if (!canRedo.value) return;
+    const [bundle, meta] = ec4.currentDbState();
+    if (!bundle || !meta || !bundle.id) throw Error('No bundle found');
+    redoFrom(bundle as DbBundle, meta as DbBundleMeta);
+    // Avoid pushing the redo onto the undo stack when saving after this operation
+    ec4.skipHistory();
+    ec4.setState(bundle as DbBundle, meta as DbBundleMeta);
+  }
+
+  return {
+    pushEdit,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    clear() {
+      undoStack.value = [];
+      redoStack.value = [];
+    },
+  };
+}

--- a/ec4-v2-vue/src/composables/storage.ts
+++ b/ec4-v2-vue/src/composables/storage.ts
@@ -4,21 +4,65 @@ import { from } from 'rxjs';
 import { Ec4Bundle } from '@/domain/Ec4Bundle.ts';
 import router from '@/router';
 
-export interface BundleMeta {
+export interface DbBundleMeta {
   id: number;
   name: string;
   timestamp: number;
 }
 
-export interface Bundle {
+export interface DbBundle {
   bytes: Uint8Array;
   id: number;
 }
 
+export class DbBundleDelta {
+  private readonly byteDelta: Map<number, number> = new Map();
+  private readonly newName: string | null = null;
+  private readonly oldName: string | null = null;
+  constructor(
+    oldBundle: DbBundle,
+    oldMeta: DbBundleMeta,
+    newBundle: DbBundle,
+    newMeta: DbBundleMeta,
+  ) {
+    // Old bytes and new bytes are always the same length. Ids also never change
+    for (let i = 0; i < oldBundle.bytes.length; i++) {
+      if (oldBundle.bytes[i] !== newBundle.bytes[i]) {
+        this.byteDelta.set(i, newBundle.bytes[i] ^ oldBundle.bytes[i]);
+      }
+    }
+    if (oldMeta.name !== newMeta.name) {
+      this.newName = newMeta.name;
+      this.oldName = oldMeta.name;
+    }
+  }
+
+  applyBinary(bytes: Uint8Array) {
+    for (const [i, v] of this.byteDelta.entries()) {
+      bytes[i] = v ^ bytes[i];
+    }
+  }
+
+  // Apply to the older bundle to get the newer bundle - for redo
+  applyForward(bundle: DbBundle, meta: DbBundleMeta) {
+    this.applyBinary(bundle.bytes);
+    if (this.newName) {
+      meta.name = this.newName;
+    }
+  }
+  // ... and to the newer bundle to get the older bundle - for undo
+  applyBackward(bundle: DbBundle, meta: DbBundleMeta) {
+    this.applyBinary(bundle.bytes);
+    if (this.oldName) {
+      meta.name = this.oldName;
+    }
+  }
+}
+
 export function useStorage() {
   const db = new Dexie('ec4-editor-settings') as Dexie & {
-    summaries: EntityTable<BundleMeta, 'id'>;
-    bundles: EntityTable<Bundle, 'id'>;
+    summaries: EntityTable<DbBundleMeta, 'id'>;
+    bundles: EntityTable<DbBundle, 'id'>;
   };
 
   db.version(1).stores({
@@ -26,37 +70,48 @@ export function useStorage() {
     bundles: '++id, bytes',
   });
 
-  const bundleMetas = useObservable<BundleMeta[]>(
-    from(liveQuery<BundleMeta[]>(async () => db.summaries.toArray())),
+  const bundleMetas = useObservable<DbBundleMeta[]>(
+    from(liveQuery<DbBundleMeta[]>(async () => db.summaries.toArray())),
   );
 
-  async function getBundle(meta: BundleMeta) {
+  async function getBundle(meta: DbBundleMeta) {
     return db.bundles.get(meta.id);
   }
 
-  async function updateBundle(meta: BundleMeta, bundle: Bundle) {
-    await db.transaction('rw', db.bundles, db.summaries, async () => {
+  async function updateBundle(meta: DbBundleMeta, bundle: DbBundle): Promise<DbBundle | null> {
+    return db.transaction('rw', db.bundles, db.summaries, async () => {
+      // Retrieve the old bytes so we can calculate the delta
+      const oldBundle = await db.bundles.get(meta.id);
       await db.bundles.put(bundle);
       await db.summaries.put(meta);
+      return oldBundle || null;
     });
   }
 
-  async function deleteBundle(meta: BundleMeta) {
+  async function deleteBundle(meta: DbBundleMeta) {
     await db.transaction('rw', db.bundles, db.summaries, async () => {
       await db.bundles.delete(meta.id);
       await db.summaries.delete(meta.id);
     });
   }
 
-  async function saveBundle(toSave: Ec4Bundle) {
+  // Returns the delta to the bundle and the delta to the meta
+  async function saveBundle(toSave: Ec4Bundle): Promise<DbBundleDelta | null> {
     // Update if it has an id, otherwise add
     const [bundle, meta] = toSave.toDb();
     const existingMeta = bundle.id ? await db.summaries.get(bundle.id) : undefined;
     if (existingMeta) {
-      await updateBundle({ ...meta, id: existingMeta.id }, { ...bundle, id: existingMeta.id });
+      const prevBundle = await updateBundle(
+        { ...meta, id: existingMeta.id },
+        { ...bundle, id: existingMeta.id },
+      );
+      return prevBundle && prevBundle.id
+        ? new DbBundleDelta(prevBundle, existingMeta, bundle as DbBundle, meta as DbBundleMeta)
+        : null;
     } else {
       const newId = await addBundle(bundle.bytes, meta.name);
       await router.push({ name: 'bundle', params: { bundleId: newId } });
+      return null;
     }
   }
 
@@ -71,7 +126,7 @@ export function useStorage() {
   async function addBundle(bytes: Uint8Array, name = '') {
     let newId = 0;
     await db.transaction('rw', db.bundles, db.summaries, async () => {
-      const meta: BundleMeta = {
+      const meta: DbBundleMeta = {
         name,
         timestamp: Date.now(),
         id: await db.bundles.add({ bytes }),

--- a/ec4-v2-vue/src/composables/useMidi.ts
+++ b/ec4-v2-vue/src/composables/useMidi.ts
@@ -1,7 +1,7 @@
 import { computed, type ComputedRef, ref, watch, type WatchHandle } from 'vue';
 import { filter, lastValueFrom, map, Subject, type Subscription, take, timeout } from 'rxjs';
 import { useEc4Store } from '@/stores/faderfox-ec4.ts';
-import { type Bundle, useStorage } from '@/composables/storage.ts';
+import { type DbBundle, useStorage } from '@/composables/storage.ts';
 
 const midi: Promise<MIDIAccess | null> =
   typeof navigator.requestMIDIAccess === 'function'
@@ -364,7 +364,7 @@ function initMidi() {
     },
   );
 
-  function sendBundle(bundle: Bundle) {
+  function sendBundle(bundle: DbBundle) {
     if (!m) return;
     selectedOutput.value?.send(bundle.bytes);
   }

--- a/ec4-v2-vue/src/domain/Ec4Bundle.ts
+++ b/ec4-v2-vue/src/domain/Ec4Bundle.ts
@@ -39,4 +39,13 @@ export class Ec4Bundle {
       },
     ];
   }
+
+  clone(): Ec4Bundle {
+    const b = new Ec4Bundle(
+      this.name,
+      this.setups.map((s) => s.clone()),
+    );
+    b.id = this.id;
+    return b;
+  }
 }

--- a/ec4-v2-vue/src/domain/Ec4Bundle.ts
+++ b/ec4-v2-vue/src/domain/Ec4Bundle.ts
@@ -1,6 +1,6 @@
 import type { EncoderSetup } from '@/domain/EncoderSetup.ts';
 import { createEmptyEncoderSetups, type PartialBy } from '@/stores/faderfox-ec4.ts';
-import type { Bundle, BundleMeta } from '@/composables/storage.ts';
+import type { DbBundle, DbBundleMeta } from '@/composables/storage.ts';
 import { generateSysexData, parseSetupsFromSysex } from '@/memoryLayout.ts';
 
 export class Ec4Bundle {
@@ -18,7 +18,7 @@ export class Ec4Bundle {
     return new Ec4Bundle('', createEmptyEncoderSetups());
   }
 
-  public static fromDb(bundle: Bundle, meta: BundleMeta) {
+  public static fromDb(bundle: DbBundle, meta: DbBundleMeta) {
     const b = Ec4Bundle.createEmpty();
     b.name = meta.name;
     b.id = meta.id;
@@ -26,7 +26,7 @@ export class Ec4Bundle {
     return b;
   }
 
-  toDb(): [PartialBy<Bundle, 'id'>, PartialBy<BundleMeta, 'id'>] {
+  toDb(): [PartialBy<DbBundle, 'id'>, PartialBy<DbBundleMeta, 'id'>] {
     return [
       {
         bytes: generateSysexData(this.setups),

--- a/ec4-v2-vue/src/stores/faderfox-ec4.ts
+++ b/ec4-v2-vue/src/stores/faderfox-ec4.ts
@@ -1,10 +1,10 @@
-import { ref, computed, type Ref } from 'vue';
+import { ref, computed, type Ref, nextTick } from 'vue';
 import { defineStore } from 'pinia';
 import { EncoderSetup } from '@/domain/EncoderSetup.ts';
 import { Ec4Bundle } from '@/domain/Ec4Bundle.ts';
 import { useStorage } from '@/composables/storage.ts';
 import { Control, type FieldType, type NumberFieldType } from '@/domain/Encoder.ts';
-import { useDebouncedRefHistory, watchDebounced } from '@vueuse/core';
+import { useRefHistory, watchDebounced } from '@vueuse/core';
 import type { EncoderGroup } from '@/domain/EncoderGroup.ts';
 import router from '@/router';
 
@@ -40,9 +40,8 @@ export const useEc4Store = defineStore('ec4', () => {
   const storage = useStorage();
   const activeBundle: Ref<Ec4Bundle> = ref(Ec4Bundle.createEmpty());
 
-  const history = useDebouncedRefHistory(activeBundle, {
+  const history = useRefHistory(activeBundle, {
     deep: true,
-    debounce: 500,
     clone: (bundle) => bundle.clone(),
   });
 
@@ -87,6 +86,9 @@ export const useEc4Store = defineStore('ec4', () => {
     selectedGroupIndex.value = 0;
     selectedEncoderIndex.value = 0;
     resetBundle();
+    nextTick(() => {
+      history.clear();
+    }).then();
     await router.push({ name: 'home' });
   }
 
@@ -112,7 +114,9 @@ export const useEc4Store = defineStore('ec4', () => {
     selectedControl,
     loadBundle: async (id: number) => {
       activeBundle.value = await storage.loadBundle(id);
-      history?.clear();
+      nextTick(() => {
+        history.clear();
+      }).then();
     },
     lastStateSaved,
     activeField,

--- a/ec4-v2-vue/src/stores/faderfox-ec4.ts
+++ b/ec4-v2-vue/src/stores/faderfox-ec4.ts
@@ -4,7 +4,7 @@ import { EncoderSetup } from '@/domain/EncoderSetup.ts';
 import { Ec4Bundle } from '@/domain/Ec4Bundle.ts';
 import { useStorage } from '@/composables/storage.ts';
 import { Control, type FieldType, type NumberFieldType } from '@/domain/Encoder.ts';
-import { watchDebounced } from '@vueuse/core';
+import { useDebouncedRefHistory, watchDebounced } from '@vueuse/core';
 import type { EncoderGroup } from '@/domain/EncoderGroup.ts';
 import router from '@/router';
 
@@ -39,6 +39,12 @@ window.addEventListener('blur', () => {
 export const useEc4Store = defineStore('ec4', () => {
   const storage = useStorage();
   const activeBundle: Ref<Ec4Bundle> = ref(Ec4Bundle.createEmpty());
+
+  const history = useDebouncedRefHistory(activeBundle, {
+    deep: true,
+    debounce: 500,
+    clone: (bundle) => bundle.clone(),
+  });
 
   const selectedSetupIndex = ref<number>(0);
 
@@ -106,6 +112,7 @@ export const useEc4Store = defineStore('ec4', () => {
     selectedControl,
     loadBundle: async (id: number) => {
       activeBundle.value = await storage.loadBundle(id);
+      history?.clear();
     },
     lastStateSaved,
     activeField,
@@ -134,5 +141,6 @@ export const useEc4Store = defineStore('ec4', () => {
       }
     },
     newBundle,
+    history,
   };
 });

--- a/ec4-v2-vue/src/stores/faderfox-ec4.ts
+++ b/ec4-v2-vue/src/stores/faderfox-ec4.ts
@@ -1,12 +1,13 @@
-import { ref, computed, type Ref, nextTick } from 'vue';
+import { ref, computed, type Ref } from 'vue';
 import { defineStore } from 'pinia';
 import { EncoderSetup } from '@/domain/EncoderSetup.ts';
 import { Ec4Bundle } from '@/domain/Ec4Bundle.ts';
-import { useStorage } from '@/composables/storage.ts';
+import { type DbBundle, type DbBundleMeta, useStorage } from '@/composables/storage.ts';
 import { Control, type FieldType, type NumberFieldType } from '@/domain/Encoder.ts';
-import { useRefHistory, watchDebounced } from '@vueuse/core';
+import { watchDebounced } from '@vueuse/core';
 import type { EncoderGroup } from '@/domain/EncoderGroup.ts';
 import router from '@/router';
+import useHistory from '@/composables/history.ts';
 
 export function* generateIds() {
   for (let i = 0; i < 16; i++) yield i;
@@ -40,11 +41,6 @@ export const useEc4Store = defineStore('ec4', () => {
   const storage = useStorage();
   const activeBundle: Ref<Ec4Bundle> = ref(Ec4Bundle.createEmpty());
 
-  const history = useRefHistory(activeBundle, {
-    deep: true,
-    clone: (bundle) => bundle.clone(),
-  });
-
   const selectedSetupIndex = ref<number>(0);
 
   const encoderGroups = computed(() => activeBundle.value.setups[selectedSetupIndex.value].groups);
@@ -63,32 +59,32 @@ export const useEc4Store = defineStore('ec4', () => {
 
   const lastStateSaved = ref(0);
 
+  const history = useHistory();
+  let historyPaused = false;
+
   // Auto save after a bit of inactivity
   watchDebounced(
     activeBundle,
-    (newBundle, oldBundle) => {
+    async (newBundle, oldBundle) => {
       // No auto save if we are loading a new bundle
       console.debug('bundle changed', newBundle?.id, oldBundle?.id, oldBundle);
       if (!oldBundle || newBundle.id !== oldBundle.id) return;
-      storage.saveBundle(activeBundle.value).then();
+      console.debug('saving bundle change', newBundle?.id, oldBundle?.id, oldBundle);
+      const delta = await storage.saveBundle(activeBundle.value);
+      if (!delta) return;
+      if (!historyPaused) history.pushEdit(delta);
+      historyPaused = false;
       lastStateSaved.value = Date.now();
     },
     { deep: true, debounce: 1000 },
   );
 
-  function resetBundle() {
-    console.log('resetBundle');
-    activeBundle.value = Ec4Bundle.createEmpty();
-  }
-
   async function newBundle() {
     selectedSetupIndex.value = 0;
     selectedGroupIndex.value = 0;
     selectedEncoderIndex.value = 0;
-    resetBundle();
-    nextTick(() => {
-      history.clear();
-    }).then();
+    activeBundle.value = Ec4Bundle.createEmpty();
+    history.clear();
     await router.push({ name: 'home' });
   }
 
@@ -114,9 +110,7 @@ export const useEc4Store = defineStore('ec4', () => {
     selectedControl,
     loadBundle: async (id: number) => {
       activeBundle.value = await storage.loadBundle(id);
-      nextTick(() => {
-        history.clear();
-      }).then();
+      history.clear();
     },
     lastStateSaved,
     activeField,
@@ -146,5 +140,14 @@ export const useEc4Store = defineStore('ec4', () => {
     },
     newBundle,
     history,
+    currentDbState() {
+      return activeBundle.value.toDb();
+    },
+    setState(bundle: DbBundle, meta: DbBundleMeta) {
+      activeBundle.value = Ec4Bundle.fromDb(bundle, meta);
+    },
+    skipHistory() {
+      historyPaused = true;
+    },
   };
 });


### PR DESCRIPTION
Looks like it became both a space and time performant solution in the end.

Each undo entry is a delta for traveling one auto-save back in time, redo likewise. The crucial observation is that there won't be many bytes changed from one save to the next, so a sparse binary delta in a map will generally perform well without the need for a hard ceiling on the undo buffer size.